### PR TITLE
Add deps.yml to help update dependencies from the CLI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,20 @@ When it's done, you'll find a self-contained package in a subdirectory named `ou
 > sh
 $ ./build-cairo-windows.sh x64
 ```
+
+# Updating dependencies
+
+The repo contains a deps.yml which can update cairo, freetype etc using dependencies.io
+
+
+To run this locally, install the commandline tool from https://deps.app/local/
+
+```
+$ curl https://deps.app/install.sh | bash -s -- -b $HOME/bin
+```
+
+Then run it, accepting all the prompts:
+```
+$ yes | deps run
+```
+

--- a/deps.yml
+++ b/deps.yml
@@ -1,0 +1,26 @@
+version: 3
+dependencies:
+- type: git
+  settings:
+    remotes:
+      git://anongit.freedesktop.org/git/cairo:
+         replace_in_files:
+         - filename: build-cairo-windows.sh
+           pattern: CAIRO_VERSION=cairo-(\S+)
+      https://github.com/freedesktop/pixman.git:
+        replace_in_files:
+        - filename: build-cairo-windows.sh
+          pattern: PIXMAN_VERSION=pixman-(\S+)
+          tag_prefix: pixman-
+      https://github.com/glennrp/libpng.git:
+        replace_in_files:
+        - filename: build-cairo-windows.sh
+          pattern: LIBPNG_VERSION=libpng-(\S+)
+          tag_prefix: v
+      git://git.sv.nongnu.org/freetype/freetype2.git:
+        replace_in_files:
+        - filename: build-cairo-windows.sh
+          pattern: FREETYPE_VERSION=freetype-(\S+)
+          tag_filter:
+            matching: 'VER-(\d+)-(\d+)-(\d+)'
+            output_as: '$1.$2.$3'  # output and sort as a semver-compatible 


### PR DESCRIPTION
The adds a deps.yml and info on running the deps cli tool to patch dependencies.
The first part of https://github.com/preshing/cairo-windows/issues/5

I've purposely put this branch one behind HEAD so you can run the tool and see it change the code to upgrade cairo etc to the current version.

The tools seems to be able to generate changes much like the PR you created to update freetype, cairo last time.
Try the tool and see what you think :)

