### PR TITLE
Add dependencies.io github workflow to upgrade cairo, freetype etc

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -1,0 +1,17 @@
+name: deps
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 5 * * *'
+
+jobs:
+  deps:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - run: curl https://deps.app/install.sh | bash -s -- -b $HOME/bin
+    - run: $HOME/bin/deps ci
+      env:
+        DEPS_TOKEN: ${{ secrets.DEPS_TOKEN }}
+        DEPS_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is the github workflow for dependencies.io originally contributed by @davegaeddert

Adding now, even though workflows are confusing me a bit - especially under what conditions they actually appear in the actions tab.

When this works, there should be an option under "Actions" to run this, via workflow dispatch.
This is also set to run once a day.

You will need to get an account with dependencies.io, and can start an evaluations, they are up for helping out open source so it's worth contacting them - I got a key for open source work.